### PR TITLE
Fix angular 11+ compilation issue in application-insights.service.ts

### DIFF
--- a/src/main/webapp/app/core/insights/application-insights.service.ts
+++ b/src/main/webapp/app/core/insights/application-insights.service.ts
@@ -16,7 +16,10 @@ export class ApplicationInsightsService {
 
   constructor(private router: Router) {
     this.appInsights.loadAppInsights();
-    this.routerSubscription = this.router.events.pipe(filter(event => event instanceof ResolveEnd)).subscribe((event: ResolveEnd) => {
+    this.routerSubscription = this.router.events.pipe(
+            filter((event): event is ResolveEnd => event instanceof ResolveEnd)
+          )
+          .subscribe(event => {
       const activatedComponent = this.getActivatedComponent(event.state.root);
       if (activatedComponent) {
         this.logPageView(`${activatedComponent.name} ${this.getRouteTemplate(event.state.root)}`, event.urlAfterRedirects);


### PR DESCRIPTION
Issue with types in the constructor for application-insights.service.ts prevents compilation in Angular 11+.  This PR fixes the issue with typing and allows compilation.